### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Java CI
+
+on:
+push:
+branches: \[ main, dev ]
+pull\_request:
+branches: \[ main ]
+
+jobs:
+build:
+runs-on: ubuntu-latest
+
+steps:
+  - name: Checkout code
+    uses: actions/checkout@v4
+
+  - name: Set up JDK 17
+    uses: actions/setup-java@v4
+    with:
+      distribution: 'temurin'
+      java-version: '17'
+
+  - name: Grant execute permission for Gradle wrapper
+    run: chmod +x gradlew
+
+  - name: Build with Gradle
+    run: ./gradlew build


### PR DESCRIPTION
This PR adds a basic GitHub Actions workflow for Java 17 using Gradle.

* Runs on push to `main` and `dev`
* Builds project with `./gradlew build`

Closes #3 
