### PR TITLE
Add basic test for 5x5 knight's tour using BacktrackingSolver

### DIFF
--- a/src/main/java/knights/solver/BacktrackingSolverTest.java
+++ b/src/main/java/knights/solver/BacktrackingSolverTest.java
@@ -1,0 +1,28 @@
+package knights.solver;
+
+import knights.model.Board;
+import knights.model.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BacktrackingSolverTest {
+
+    @Test
+    void testFindOpenTour5x5From00() {
+        int rows = 5, cols = 5;
+        Board board = new Board(rows, cols);
+        Position start = new Position(0, 0);
+        TourSolver solver = new BacktrackingSolver(board, start);
+
+        List<Position> solution = solver.solve();
+
+        assertEquals(rows * cols, solution.size(), "The tour should visit all cells");
+        assertFalse(solution.isEmpty(), "Solution should not be empty");
+
+        // Optional: print to check visually during dev
+        board.print();
+    }
+}


### PR DESCRIPTION
This PR adds a simple JUnit test for the BacktrackingSolver class.
It checks that a knight's tour is successfully found on a 5x5 board starting from position (0, 0), and that the solution covers all board cells.