### PR TITLE
feat: add flag open/closed to solver algorithm

### DIFF
--- a/src/main/java/knights/Main.java
+++ b/src/main/java/knights/Main.java
@@ -10,9 +10,10 @@ import java.util.List;
 
 public class Main {
     public static void main(String[] args) {
-        if (args.length < 5) {
-            System.out.println("Usage: java -jar knights-tour.jar <rows> <cols> <startRow> <startCol> <mode>");
-            System.out.println("Example: java -jar knights-tour.jar 5 5 0 0 single");
+        if (args.length < 6) {
+            System.out.println(
+                    "Usage: java -jar knights-tour.jar <rows> <cols> <startRow> <startCol> <mode> <tourType>");
+            System.out.println("Example: java -jar knights-tour.jar 5 5 0 0 single open");
             return;
         }
 
@@ -21,15 +22,17 @@ public class Main {
         int startRow = Integer.parseInt(args[2]);
         int startCol = Integer.parseInt(args[3]);
         String mode = args[4];
+        String tourType = args[5];
+        boolean isClosed = tourType.equalsIgnoreCase("closed");
 
-        System.out.printf("Board: %dx%d | Start: (%d,%d) | Mode: %s\n",
-                rows, cols, startRow, startCol, mode);
+        System.out.printf("Board: %dx%d | Start: (%d,%d) | Mode: %s | Tour: %s\n",
+                rows, cols, startRow, startCol, mode, isClosed ? "closed" : "open");
 
         Board board = new Board(rows, cols);
         Position start = new Position(startRow, startCol);
 
         if (mode.equalsIgnoreCase("all")) {
-            BacktrackingAllSolutionsSolver solver = new BacktrackingAllSolutionsSolver(board, start, false);
+            BacktrackingAllSolutionsSolver solver = new BacktrackingAllSolutionsSolver(board, start, isClosed);
             List<List<Position>> allSolutions = solver.solveAll();
             System.out.printf("Found %d solutions.%n", allSolutions.size());
 
@@ -44,7 +47,7 @@ public class Main {
                 board.print();
             }
         } else {
-            TourSolver solver = new BacktrackingSolver(board, start, false);
+            TourSolver solver = new BacktrackingSolver(board, start, isClosed);
             List<Position> solution = solver.solve();
             if (solution.isEmpty()) {
                 System.out.println("No solution found.");


### PR DESCRIPTION
This PR adds support for selecting between open and closed knight’s tours via a command-line argument (tourType).
The program now interprets the sixth argument as "closed" (case-insensitive) and passes this as a boolean to the solver.

Updated usage:

```bash
java -jar knights-tour-pro-1.0.jar <rows> <cols> <startRow> <startCol> <mode> <tourType>
```

Example:
```bash
java -jar knights-tour-pro-1.0.jar 5 5 0 0 single open
java -jar knights-tour-pro-1.0.jar 5 5 0 0 all closed
```
If fewer than 6 arguments are provided, a usage message is displayed.

Closes #28 