### PR TITLE
test: 5x5 open & 6x6 closed

### DIFF
--- a/src/main/java/knights/model/Position.java
+++ b/src/main/java/knights/model/Position.java
@@ -1,7 +1,5 @@
 package knights.model;
 
-import java.util.Objects;
-
 /**
  * Represents a coordinate (row, col) on the board.
  */

--- a/src/test/java/knights/solver/BacktrackingSolverClosedTourTest.java
+++ b/src/test/java/knights/solver/BacktrackingSolverClosedTourTest.java
@@ -1,0 +1,40 @@
+package knights.solver;
+
+import knights.model.Board;
+import knights.model.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BacktrackingSolverClosedTourTest {
+
+    @Test
+    void testNoClosedTourExistsOn5x5Board() {
+        int rows = 5, cols = 5;
+        Board board = new Board(rows, cols);
+        Position start = new Position(0, 0);
+        TourSolver solver = new BacktrackingSolver(board, start, true); // closed = true
+
+        List<Position> solution = solver.solve();
+
+        assertTrue(solution.isEmpty(), "There should be no closed tour on a 5x5 board");
+    }
+
+    @Test
+    void testClosedTourExistsOn6x6Board() {
+        int rows = 6, cols = 6;
+        Board board = new Board(rows, cols);
+        Position start = new Position(0, 0);
+        TourSolver solver = new BacktrackingSolver(board, start, true); // closed = true
+
+        List<Position> solution = solver.solve();
+
+        assertEquals(rows * cols, solution.size(), "The tour should visit all cells");
+        assertFalse(solution.isEmpty(), "Solution should not be empty");
+
+        Position end = solution.get(solution.size() - 1);
+        assertTrue(end.isAdjacent(start), "In a closed tour, last move must connect to start");
+    }
+}


### PR DESCRIPTION
This PR introduces a new test class `BacktrackingSolverClosedTourTest` to verify behavior when solving closed knight's tours.

Includes:
- testNoClosedTourExistsOn5x5Board — asserts that a closed tour does not exist on a 5×5 board.
- testClosedTourExistsOn6x6Board — checks that a valid closed tour is found on a 6×6 board and that it ends adjacent to the starting position.

These tests help ensure the solver behaves correctly with the closed flag enabled.