### PR TITLE
feat: add warnsdorff algorithm & test

### DIFF
--- a/src/main/java/knights/model/Board.java
+++ b/src/main/java/knights/model/Board.java
@@ -1,6 +1,7 @@
 package knights.model;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Represents the knight's tour board with move order tracking.
@@ -66,5 +67,11 @@ public class Board {
             }
             System.out.println();
         }
+    }
+
+    public List<Position> legalMoves(Position from) {
+        return KnightMove.generateNextPositions(from).stream()
+                .filter(this::isInside)
+                .toList();
     }
 }

--- a/src/main/java/knights/solver/WarnsdorffSolver.java
+++ b/src/main/java/knights/solver/WarnsdorffSolver.java
@@ -1,0 +1,58 @@
+package knights.solver;
+
+import knights.model.Board;
+import knights.model.Position;
+
+import java.util.*;
+
+/**
+ * Solver based on Warnsdorff's heuristic: always move to the square with the
+ * fewest onward moves.
+ */
+public class WarnsdorffSolver implements TourSolver {
+
+    private final Board board;
+    private final Position start;
+    private final boolean closed;
+
+    public WarnsdorffSolver(Board board, Position start, boolean closed) {
+        this.board = board;
+        this.start = start;
+        this.closed = closed;
+    }
+
+    @Override
+    public List<Position> solve() {
+        List<Position> path = new ArrayList<>();
+        board.reset();
+
+        Position current = start;
+        for (int step = 0; step < board.totalCells(); step++) {
+            board.mark(current, step);
+            path.add(current);
+            current = selectNext(current);
+            if (current == null && step != board.totalCells() - 1) {
+                return Collections.emptyList();
+            }
+        }
+
+        if (!closed || path.getLast().isAdjacent(start)) {
+            return path;
+        }
+
+        return Collections.emptyList();
+    }
+
+    private Position selectNext(Position pos) {
+        return board.legalMoves(pos).stream()
+                .filter(p -> !board.isVisited(p))
+                .min(Comparator.comparingInt(this::warnsdorffScore))
+                .orElse(null);
+    }
+
+    private int warnsdorffScore(Position p) {
+        return (int) board.legalMoves(p).stream()
+                .filter(n -> !board.isVisited(n))
+                .count();
+    }
+}

--- a/src/test/java/knights/solver/WarnsdorffSolverTest.java
+++ b/src/test/java/knights/solver/WarnsdorffSolverTest.java
@@ -1,0 +1,25 @@
+package knights.solver;
+
+import knights.model.Board;
+import knights.model.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WarnsdorffSolverTest {
+
+    @Test
+    void testWarnsdorffFindsTourOn8x8Board() {
+        int rows = 8, cols = 8;
+        Board board = new Board(rows, cols);
+        Position start = new Position(0, 0);
+        TourSolver solver = new WarnsdorffSolver(board, start, false);
+
+        List<Position> solution = solver.solve();
+
+        assertEquals(rows * cols, solution.size(), "Tour must visit all cells");
+        assertFalse(solution.isEmpty(), "Solution should not be empty");
+    }
+}


### PR DESCRIPTION
This PR introduces a new solver implementation: WarnsdorffSolver, which uses Warnsdorff's heuristic to efficiently find knight's tours by always moving to the square with the fewest onward moves.

### Changes included:
- New class: WarnsdorffSolver implementing TourSolver
        - Supports both open and closed tours
        - Uses a greedy strategy based on Warnsdorff’s rule

- New test class: WarnsdorffSolverTest
        - Basic test: verifies that the solver successfully finds a complete open tour on an 8×8 board starting at (0, 0)

### Notes:
- Closed tour support is included, but only open tour is tested so far.ç
- This solver provides a fast non-backtracking alternative to the existing backtracking solvers.

Closes #35 