### PR TITLE
fix: replaced function to compatiblity java versions

### DIFF
--- a/src/main/java/knights/solver/WarnsdorffSolver.java
+++ b/src/main/java/knights/solver/WarnsdorffSolver.java
@@ -36,7 +36,7 @@ public class WarnsdorffSolver implements TourSolver {
             }
         }
 
-        if (!closed || path.getLast().isAdjacent(start)) {
+        if (!closed || path.get(path.size() - 1).isAdjacent(start)) {
             return path;
         }
 


### PR DESCRIPTION
This PR fixes a Java compilation error in `WarnsdorffSolver.java` caused by the use of `List.getLast()`, which is not available in standard `List` implementations.

**Fix:**
Replaced:

```java
path.getLast()
```

with:

```java
path.get(path.size() - 1)
```

This ensures compatibility with all supported Java versions and allows the GitHub Actions build to pass.
