### PR TITLE
feat: add strategy selector as arg & tests

### DIFF
--- a/src/main/java/knights/Main.java
+++ b/src/main/java/knights/Main.java
@@ -2,9 +2,7 @@ package knights;
 
 import knights.model.Board;
 import knights.model.Position;
-import knights.solver.BacktrackingAllSolutionsSolver;
-import knights.solver.BacktrackingSolver;
-import knights.solver.TourSolver;
+import knights.solver.*;
 
 import java.util.List;
 
@@ -12,8 +10,10 @@ public class Main {
     public static void main(String[] args) {
         if (args.length < 6) {
             System.out.println(
-                    "Usage: java -jar knights-tour.jar <rows> <cols> <startRow> <startCol> <mode> <tourType>");
-            System.out.println("Example: java -jar knights-tour.jar 5 5 0 0 single open");
+                    "Usage: java -jar knights-tour.jar <rows> <cols> <startRow> <startCol> <mode> <tourType> [strategy]");
+            System.out.println("mode: single | all");
+            System.out.println("tourType: open | closed");
+            System.out.println("strategy (optional): backtrack (default) | warnsdorff");
             return;
         }
 
@@ -23,15 +23,24 @@ public class Main {
         int startCol = Integer.parseInt(args[3]);
         String mode = args[4];
         String tourType = args[5];
+        String strategy = args.length >= 7 ? args[6] : "backtrack";
+
         boolean isClosed = tourType.equalsIgnoreCase("closed");
 
-        System.out.printf("Board: %dx%d | Start: (%d,%d) | Mode: %s | Tour: %s\n",
-                rows, cols, startRow, startCol, mode, isClosed ? "closed" : "open");
+        System.out.printf("Board: %dx%d | Start: (%d,%d) | Mode: %s | Tour: %s | Strategy: %s\n",
+                rows, cols, startRow, startCol, mode,
+                isClosed ? "closed" : "open",
+                strategy);
 
         Board board = new Board(rows, cols);
         Position start = new Position(startRow, startCol);
 
         if (mode.equalsIgnoreCase("all")) {
+            if ("warnsdorff".equalsIgnoreCase(strategy)) {
+                System.out.println("Warnsdorff strategy does not support generating all solutions.");
+                return;
+            }
+
             BacktrackingAllSolutionsSolver solver = new BacktrackingAllSolutionsSolver(board, start, isClosed);
             List<List<Position>> allSolutions = solver.solveAll();
             System.out.printf("Found %d solutions.%n", allSolutions.size());
@@ -47,8 +56,15 @@ public class Main {
                 board.print();
             }
         } else {
-            TourSolver solver = new BacktrackingSolver(board, start, isClosed);
+            TourSolver solver;
+            if ("warnsdorff".equalsIgnoreCase(strategy)) {
+                solver = new WarnsdorffSolver(board, start, isClosed);
+            } else {
+                solver = new BacktrackingSolver(board, start, isClosed);
+            }
+
             List<Position> solution = solver.solve();
+
             if (solution.isEmpty()) {
                 System.out.println("No solution found.");
             } else {

--- a/src/test/java/knights/solver/CLITest.java
+++ b/src/test/java/knights/solver/CLITest.java
@@ -1,0 +1,65 @@
+package knights.solver;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import knights.Main;
+
+class CLITest {
+
+    @Test
+    void testMainWarnsdorffSingleOpen() {
+        String[] args = { "8", "8", "0", "0", "single", "open", "warnsdorff" };
+
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+
+        Main.main(args);
+
+        System.setOut(originalOut);
+        String output = outContent.toString();
+
+        assertTrue(output.contains("Board: 8x8"));
+        assertTrue(output.contains("Strategy: warnsdorff"));
+        assertTrue(output.contains("0") || output.contains("."), "Should print a board or solution");
+    }
+
+    @Test
+    void testMainBacktrackAllOpen() {
+        String[] args = { "5", "5", "0", "0", "all", "open", "backtrack" };
+
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+
+        Main.main(args);
+
+        System.setOut(originalOut);
+        String output = outContent.toString();
+
+        assertTrue(output.contains("Found"));
+        assertTrue(output.contains("Solution #1"));
+        assertTrue(output.contains("0") || output.contains("."), "Should print a board or solution");
+    }
+
+    @Test
+    void testMainBacktrackSingleClosedNoSolution() {
+        String[] args = { "5", "5", "0", "0", "single", "closed", "backtrack" };
+
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+
+        Main.main(args);
+
+        System.setOut(originalOut);
+        String output = outContent.toString();
+
+        assertTrue(output.contains("No solution found."));
+    }
+}


### PR DESCRIPTION
This PR extends the main program to support specifying the solving **strategy** as an optional 7th CLI argument.
It also includes basic tests to validate this functionality.

**Changes:**

- `Main.java` updated to accept:
        * `strategy` argument: `backtrack` (default) or `warnsdorff`
        * Displays the selected strategy in the console output
        * Prevents using `warnsdorff` with `mode=all` (not supported)

- New test class: `CLITest`
        * Tests for:
                * `warnsdorff`, `single`, `open`
                * `backtrack`, `all`, `open`
                * `backtrack`, `single`, `closed` with no solution

**Usage:**
```bash
java -jar knights-tour-pro-1.0.jar 8 8 0 0 single open warnsdorff
```

**Notes:**

* Backtracking remains the default strategy if none is provided.
* Warnsdorff strategy prioritizes speed but does not support multiple solutions.

Close #29