### PR TITLE
feat: backtrack & warnsdorff benchmark & updated dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     java
     application
+    id("me.champeau.jmh") version "0.7.2"
 }
 
 group = "knights"
@@ -20,8 +21,10 @@ repositories {
 }
 
 dependencies {
-    implementation ("com.google.code.gson:gson:2.10.1")
+    implementation("com.google.code.gson:gson:2.10.1")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
+    jmh("org.openjdk.jmh:jmh-core:1.37")
+    jmh("org.openjdk.jmh:jmh-generator-annprocess:1.37")
 }
 
 application {
@@ -34,4 +37,17 @@ tasks.jar {
     }
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+}
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.addAll(listOf("-Xlint:unchecked", "-Xlint:deprecation"))
+}
+
+// Enable benchmarking
+jmh {
+    warmupIterations.set(3)
+    iterations.set(5)
+    fork.set(1)
+    benchmarkMode.set(listOf("Throughput"))
+    timeUnit.set("ms")
 }

--- a/src/jmh/java/knights/benchmark/BacktrackingBenchmark.java
+++ b/src/jmh/java/knights/benchmark/BacktrackingBenchmark.java
@@ -1,0 +1,33 @@
+package knights.benchmark;
+
+import knights.model.Board;
+import knights.model.Position;
+import knights.solver.BacktrackingSolver;
+import knights.solver.TourSolver;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class BacktrackingBenchmark {
+
+    @Param({ "5", "6" })
+    public int size;
+
+    private TourSolver solver;
+
+    @Setup(Level.Invocation)
+    public void setup() {
+        Board board = new Board(size, size);
+        Position start = new Position(0, 0);
+        solver = new BacktrackingSolver(board, start, false);
+    }
+
+    @Benchmark
+    public List<Position> solveTour() {
+        return solver.solve();
+    }
+}

--- a/src/jmh/java/knights/benchmark/WarnsdorffBenchmark.java
+++ b/src/jmh/java/knights/benchmark/WarnsdorffBenchmark.java
@@ -1,0 +1,33 @@
+package knights.benchmark;
+
+import knights.model.Board;
+import knights.model.Position;
+import knights.solver.TourSolver;
+import knights.solver.WarnsdorffSolver;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class WarnsdorffBenchmark {
+
+    @Param({ "5", "6" })
+    public int size;
+
+    private TourSolver solver;
+
+    @Setup(Level.Invocation)
+    public void setup() {
+        Board board = new Board(size, size);
+        Position start = new Position(0, 0);
+        solver = new WarnsdorffSolver(board, start, false);
+    }
+
+    @Benchmark
+    public List<Position> solveTour() {
+        return solver.solve();
+    }
+}


### PR DESCRIPTION
This PR introduces basic JMH benchmarks to measure the throughput of the Knight's Tour solvers:

* Added `BacktrackingBenchmark` and `WarnsdorffBenchmark` classes under `knights.benchmark` package.
* Benchmarks execute the `solve()` method for board sizes 5x5 and 6x6.
* Updated `build.gradle.kts` to include JMH plugin (`me.champeau.jmh`) and configured basic benchmarking parameters (warmup, iterations, mode, etc.).

These benchmarks will help evaluate the performance differences between the backtracking and Warnsdorff heuristics.

Closes #44 