### PR TITLE
feat: updated main class to add parallel strategy

### DIFF
--- a/src/main/java/knights/Main.java
+++ b/src/main/java/knights/Main.java
@@ -4,6 +4,7 @@ import knights.model.Board;
 import knights.model.Position;
 
 import knights.solver.*;
+import knights.solver.parallel.ParallelBacktrackingSolver;
 
 import knights.export.*;
 
@@ -18,7 +19,7 @@ public class Main {
                     "Usage: java -jar knights-tour.jar <rows> <cols> <startRow> <startCol> <mode> <tourType> [strategy]");
             System.out.println("mode: single | all");
             System.out.println("tourType: open | closed");
-            System.out.println("strategy (optional): backtrack (default) | warnsdorff");
+            System.out.println("strategy (optional): backtrack (default) | warnsdorff | parallel");
             return;
         }
 
@@ -32,7 +33,7 @@ public class Main {
 
         boolean isClosed = tourType.equalsIgnoreCase("closed");
 
-        System.out.printf("Board: %dx%d | Start: (%d,%d) | Mode: %s | Tour: %s | Strategy: %s\n",
+        System.out.printf("Board: %dx%d | Start: (%d,%d) | Mode: %s | Tour: %s | Strategy: %s%n",
                 rows, cols, startRow, startCol, mode,
                 isClosed ? "closed" : "open",
                 strategy);
@@ -53,18 +54,24 @@ public class Main {
                 "strategy", strategy);
 
         if (mode.equalsIgnoreCase("all")) {
+            List<List<Position>> allSolutions;
+
             if ("warnsdorff".equalsIgnoreCase(strategy)) {
                 System.out.println("Warnsdorff strategy does not support generating all solutions.");
                 return;
+            } else if ("parallel".equalsIgnoreCase(strategy)) {
+                ParallelBacktrackingSolver solver = new ParallelBacktrackingSolver(board, start, isClosed);
+                allSolutions = solver.solveAll();
+            } else {
+                BacktrackingAllSolutionsSolver solver = new BacktrackingAllSolutionsSolver(board, start, isClosed);
+                allSolutions = solver.solveAll();
             }
 
-            BacktrackingAllSolutionsSolver solver = new BacktrackingAllSolutionsSolver(board, start, isClosed);
-            List<List<Position>> allSolutions = solver.solveAll();
             System.out.printf("Found %d solutions.%n", allSolutions.size());
 
             int toPrint = Math.min(3, allSolutions.size());
             for (int i = 0; i < toPrint; i++) {
-                System.out.printf("\nSolution #%d:%n", i + 1);
+                System.out.printf("%nSolution #%d:%n", i + 1);
                 board.reset();
                 List<Position> solution = allSolutions.get(i);
                 for (int j = 0; j < solution.size(); j++) {
@@ -73,30 +80,49 @@ public class Main {
                 board.print();
             }
 
+            // Export (multiple)
             txtExporter.exportMultiple(allSolutions, metadata, "output/tours.txt");
             jsonExporter.exportMultiple(allSolutions, metadata, "output/tours.json");
 
-        } else {
+        } else { // single
             TourSolver solver;
+
             if ("warnsdorff".equalsIgnoreCase(strategy)) {
                 solver = new WarnsdorffSolver(board, start, isClosed);
+            } else if ("parallel".equalsIgnoreCase(strategy)) {
+                // Parallel solver para una sola solución
+                ParallelBacktrackingSolver psolver = new ParallelBacktrackingSolver(board, start, isClosed);
+                List<Position> solution = psolver.solve();
+                handleSingleResult(board, solution, txtExporter, jsonExporter, metadata);
+                return;
             } else {
                 solver = new BacktrackingSolver(board, start, isClosed);
             }
 
             List<Position> solution = solver.solve();
-
-            if (solution.isEmpty()) {
-                System.out.println("No solution found.");
-            } else {
-                for (int i = 0; i < solution.size(); i++) {
-                    board.mark(solution.get(i), i);
-                }
-                board.print();
-
-                txtExporter.exportSingle(solution, metadata, "output/tour.txt");
-                jsonExporter.exportSingle(solution, metadata, "output/tour.json");
-            }
+            handleSingleResult(board, solution, txtExporter, jsonExporter, metadata);
         }
+    }
+
+    private static void handleSingleResult(
+            Board board,
+            List<Position> solution,
+            ResultExporter txtExporter,
+            ResultExporter jsonExporter,
+            Map<String, Object> metadata) {
+        if (solution.isEmpty()) {
+            System.out.println("No solution found.");
+            return;
+        }
+        // Pintar matriz
+        board.reset();
+        for (int i = 0; i < solution.size(); i++) {
+            board.mark(solution.get(i), i);
+        }
+        board.print();
+
+        // Export (single)
+        txtExporter.exportSingle(solution, metadata, "output/tour.txt");
+        jsonExporter.exportSingle(solution, metadata, "output/tour.json");
     }
 }


### PR DESCRIPTION
Updated Main class to add "parallel" as a valid strategy option:
- Allows parallel search for both single and multiple tours.
- Uses ParallelBacktrackingSolver when "parallel" is selected.
- Refactored single-solution handling into a handleSingleResult helper method for cleaner code.
- Preserves export behavior (tour.txt / tour.json and tours.txt / tours.json).

Closes #56 